### PR TITLE
Add .gitignore rule for Python Egg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.pyo
 .idea/*
+django_wmd_editor.egg-info


### PR DESCRIPTION
When installing with PIP an egg is created. This will ignore that egg.
