### PR TITLE
Have setup.py install CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.pyo
 .idea/*
+django_wmd_editor.egg-info

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Django WMD Editor
 =================
 
 
-A [WMD-Editor][1] wrapper for django application.
+A [WMD-Editor][1] wrapper for Django applications.
 
 
 Installation
@@ -11,31 +11,33 @@ Installation
 Installing django-wmd-editor should be really as easy as possible. To install
 django-wmd-editor all you need to do is just follow these steps:
 
-1. Get django-wmd-editor
+1. Download and install django-wmd-editor.
     
-    1.1 pip install the lates version of django-wmd-editor from github
+    You can use `PIP` to install the latest version of django-wmd-editor from github like so:
     
         $ pip install -e git://github.com/marcuswhybrow/django-wmd-editor.git#egg=django_wmd_editor
+    
+    or you can run `python setup.py install`.
 
 3. Install django-wmd-editor in your django application
 
-    INSTALLED_APPS = (
-      ...
-      'wmd',
-      ...
-    )
+        INSTALLED_APPS = (
+          ...
+          'wmd',
+          ...
+        )
 
-4. In the wmd.js file on line 49, it explicitly states where images are located in your project. By default this is set to "/static/wmd/images", you must change this if your static files are located elsewhere.
+4. In the `wmd.js` file on line 49, it explicitly states where images are located in your project. By default this is set to `"/static/wmd/images"`, you must change this if your static files are located elsewhere.
 
-    4.1 Run `python manage.py collectstatic` to collate the static files in all of your apps (including this one).
+    Run `python manage.py collectstatic` to collect the static files in all of your apps (including this one).
 
-5. Add the urls to your urlconf:
+5. Add the urls to your `urls.py`:
 
-    urlpatterns = patterns('',
-      ...
-      (r'^wmd/', include('wmd.urls')),
-      ...
-    )
+        urlpatterns = patterns('',
+          ...
+          (r'^wmd/', include('wmd.urls')),
+          ...
+        )
 
 
 Usage
@@ -43,21 +45,21 @@ Usage
 
 1. In your models
 
-    from wmd import models as wmd_models
+        from wmd import models as wmd_models
 
-    description = wmd_models.MarkDownField()
+        description = wmd_models.MarkDownField()
 
 2. In your forms
 
-    from wmd.widgets import MarkDownInput
+        from wmd.widgets import MarkDownInput
 
-    description = forms.CharField(widget=MarkDownInput())
+        description = forms.CharField(widget=MarkDownInput())
 
 3. You also need to add these lines on your template to load the wmd static files.
    
-    <head>
-    {{ form.media }}
-    </head>
+        <head>
+        {{ form.media }}
+        </head>
    
 - In the admin, these static files are loaded automatically.
 
@@ -67,11 +69,10 @@ Configuration
 
 In your django settings file, use this configuration for setting up your django wmd editor
 
-- **WMD_SHOW_PREVIEW**: Whether to show the preview or not. This is the setting if you
-   use the wmd editor outside the admin.
+- `WMD_SHOW_PREVIEW`: Whether to show the preview or not. This is the setting if you use the wmd editor outside the admin.
    Values: True, False
    Default: False
-- **WMD_ADMIN_SHOW_PREVIEW**: Whether to show the preview in the admin or not.
+- `WMD_ADMIN_SHOW_PREVIEW`: Whether to show the preview in the admin or not.
    Values: True, False
    Default: True
 
@@ -84,7 +85,7 @@ Just file it in the [issue tracker][3].
 
 License
 -------
-Copyright (c) 2009 Scrum8 (http://scrum8.com), 2011 Marcus Whybrow under BSD License.
+Copyright &copy; 2009 Scrum8 (<http://scrum8.com>), 2011 Marcus Whybrow under BSD License.
 
 
   [1]: http://wmd-editor.com

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,10 @@
 
 from distutils.core import setup
 
-app_name = 'wmd'
-
-setup(name='django-%s-editor' % app_name,
+setup(name='django-wmd-editor',
         version='0.9.0',
         packages=[app_name],
-        package_data = {app_name: ['static/wmd/*.js', 'static/wmd/images/*.png']},
+        package_data = {app_name: ['static/wmd/*.js', 'static/wmd/*.css', 'static/wmd/images/*.png']},
         author = 'Joshua Partogi',
         author_email = 'joshua.partogi@gmail.com',
         url = 'http://github.com/marcuswhybrow/django-wmd-editor/',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,9 @@
 
 from distutils.core import setup
 
-setup(name='django-wmd-editor',
+app_name = 'wmd'
+
+setup(name='django-%s-editor' % app_name,
         version='0.9.0',
         packages=[app_name],
         package_data = {app_name: ['static/wmd/*.js', 'static/wmd/*.css', 'static/wmd/images/*.png']},

--- a/wmd/static/wmd/wmd.css
+++ b/wmd/static/wmd/wmd.css
@@ -1,80 +1,91 @@
-body {
-	background-color: White
-}
 
 .wmd-panel {
-	margin-left: 25%;
-	margin-right: 25%;
-	width: 50%;
-	min-width: 500px;
+    min-width: 500px;
 }
 
 #wmd-editor {
-	background-color: none;
+    background-color: none;
 }
 
 #wmd-button-bar {
-	width: 100%;
+    background: #fff;
+    margin: 5px 0;
+    padding: 5px;
+}
+#wmd-button-bar:after {
+    clear: both;
+    content: '&nbsp;';
+    display: block;
+    font-size: 0;
+    line-height: 0;
+    visibility: hidden;
+    width: 0;
+    height: 0;
 }
 
 #wmd-input {
-	height: 500px;
-	width: 100%;
-	background-color: #efefef;
-	border: 1px solid DarkGray;
+    height: 500px;
+    width: 100%;
+    background-color: #fff;
+    border: 1px solid darkgray;
 }
 
-#wmd-preview {
-	border: 1px dashed #999;
-}
+#wmd-preview {}
 
 #wmd-output {
-	background-color: none;
+    background-color: none;
 }
 
 #wmd-button-row {
-	position: relative; 
-	margin-left: 5px;
-	margin-right: 5px;
-	margin-bottom: 5px;
-	margin-top: 10px;
-	padding: 0px;  
-	height: 20px;
+    position: relative; 
+    margin: 0;
+    padding: 0px;  
+    height: 25px;
+    width: 100%;
+}
+#wmd-button-row:after {
+    clear: both;
+    content: '&nbsp;';
+    display: block;
+    font-size: 0;
+    line-height: 0;
+    visibility: hidden;
+    width: 0;
+    height: 0;
 }
 
 .wmd-spacer {
-	width: 1px; 
-	height: 20px; 
-	margin-left: 14px;
-	
-	position: absolute;
-	background-color: Silver;
-	display: inline-block; 
-	list-style: none;
+    width: 1px; 
+    height: 20px; 
+    margin-left: 14px;
+    position: absolute;
+    background-color: silver;
+    display: inline-block; 
+    list-style: none;
 }
 
 .wmd-button {
-	width: 20px; 
-	height: 20px; 
-	margin-left: 5px;
-	margin-right: 5px;
-	
-	position: absolute;
-	background-image: url(images/wmd-buttons.png);
-	background-repeat: no-repeat;
-	background-position: 0px 0px;
-	display: inline-block; 
-	list-style: none;
+    width: 20px; 
+    height: 20px; 
+    margin-left: 5px;
+    margin-right: 5px;
+    
+    position: absolute;
+    background-image: url(images/wmd-buttons.png);
+    background-repeat: no-repeat;
+    background-position: 0px 0px;
+    display: inline-block; 
+    list-style: none;
 }
 
 .wmd-button > a {
-	width: 20px; 
-	height: 20px; 
-	margin-left: 5px;
-	margin-right: 5px;
-	
-	position: absolute;
-	display: inline-block; 
+    width: 20px; 
+    height: 20px; 
+    margin-left: 5px;
+    margin-right: 5px;
+    
+    position: absolute;
+    display: inline-block; 
 }
 
 
@@ -98,34 +109,32 @@ body {
 
 
 .wmd-prompt-background {
-	background-color: Black;
+    background-color: #000;
 }
 
 .wmd-prompt-dialog {
-	border: 1px solid #999999;
-	background-color: #F5F5F5;
+    border: 1px solid #999;
+    background-color: #F5F5F5;
 }
 
 .wmd-prompt-dialog > div {
-	font-size: 0.8em;
-	font-family: arial, helvetica, sans-serif;
+    font-family: arial, helvetica, sans-serif;
 }
 
 
 .wmd-prompt-dialog > form > input[type="text"] {
-	border: 1px solid #999999;
-	color: black;
+    border: 1px solid #999;
+    color: black;
 }
 
 .wmd-prompt-dialog > form > input[type="button"]{
-	border: 1px solid #888888;
-	font-family: trebuchet MS, helvetica, sans-serif;
-	font-size: 0.8em;
-	font-weight: bold;
+    border: 1px solid #888;
+    font-family: "Trebuchet MS", "Helvetica Neue", Helvetica, sans-serif;
+    font-weight: bold;
 }
 
 
-# django-wmd overrides to make admin interface look ok
+/* django-wmd overrides to make admin interface look ok */
 .wmd-panel {text-align: left;}
 .wmd-admin {
     text-align: left;


### PR DESCRIPTION
Currently when installing with setup.py (or via PIP) the CSS file is not copied over because a rule was lacking for it in the package_data list. I have added a rule for the CSS file and it is now copying over correctly.
